### PR TITLE
Fix regex for detecting numbers

### DIFF
--- a/ftdetect/sparql.vim
+++ b/ftdetect/sparql.vim
@@ -9,6 +9,7 @@
 augroup filetypedetect
   au! BufRead,BufNewFile,BufWritePost *.rq setfiletype sparql
   au! BufRead,BufNewFile,BufWritePost *.ru setfiletype sparql
+  au! BufRead,BufNewFile,BufWritePost *.sparql setfiletype sparql
 augroup END
 
 " Set fold method to syntax and fold level appropriately

--- a/syntax/sparql.vim
+++ b/syntax/sparql.vim
@@ -96,13 +96,13 @@ syntax match sparqlIri /<[^<>'{}|^`\u00-\u20]*>/ contains=sparqlCodepointEscape 
 "  escapes: )
 syntax match sparqlVar /[?$]\{1\}\(\w\|\\U\x\{8\}\|\\u\x\{4\}\)\+/ contains=sparqlCodepointEscape
 
-" 19.8 - Numerics - Productions 146, 147 and 148
+" 19.8 - Numerics - Productions 146-154
 syntax case ignore
-syntax match sparqlInteger "\v\d+"
-syntax match sparqlDecimal "\v\d+\.\d+"
-syntax match sparqlDouble "\v\d+\.?\d*[eE][-+]?\d+"
-syntax match sparqlExpOnlyDouble "\v\.[eE][-+]?\d+"
-syntax match sparqlNoFloatingPointDouble "\v\d+[eE][-+]?\d+"
+syntax match sparqlInteger "\s[+-]\=\d\+"
+syntax match sparqlDecimal "\s[+-]\=\d\+\.\d\+"
+syntax match sparqlDouble "\s[+-]\=\d\+\.\d*[eE][+-]\=\d\+"
+syntax match sparqlExpOnlyDouble "\s[+-]\=\.[eE][+-]\=\d\+"
+syntax match sparqlNoFloatingPointDouble "\s[+-]\=\d\+[eE][+-]\=\d\+"
 
 " Apply highlighting
 highlight link sparqlKeyword Keyword 


### PR DESCRIPTION
The regexes for detecting numbers were incorrectly, due to vim-specific differences in regex syntax.
Also I added .sparql as a file extension.